### PR TITLE
Fix page title

### DIFF
--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -51,7 +51,6 @@ const SEO: FunctionComponent<Props> = ({
 
   const metaDescription = description || site.siteMetadata.description;
   const defaultImage = image || `${site.siteMetadata.siteUrl}/logo.png`;
-  const defaultTitle = `${title} | ${site.siteMetadata.title}`;
 
   const customMeta: Meta[] = [
     {
@@ -60,7 +59,7 @@ const SEO: FunctionComponent<Props> = ({
     },
     {
       property: "og:title",
-      content: defaultTitle,
+      content: title,
     },
     {
       property: "og:description",
@@ -88,7 +87,7 @@ const SEO: FunctionComponent<Props> = ({
     },
     {
       name: "twitter:title",
-      content: defaultTitle,
+      content: title,
     },
     {
       name: "twitter:description",
@@ -114,7 +113,6 @@ const SEO: FunctionComponent<Props> = ({
         lang,
       }}
       title={title}
-      titleTemplate={`%s | ${site.siteMetadata.title}`}
       meta={customMeta.concat(meta)}
     />
   );


### PR DESCRIPTION
- Adjust the title assignment to directly use the provided title without appending the site metadata title
- Remove the title template for a cleaner SEO setup
- Ensure that the component maintains the flexibility of setting a custom title while streamlining the output